### PR TITLE
Fix default init being private

### DIFF
--- a/Sources/CountryKit/Models/Continent.swift
+++ b/Sources/CountryKit/Models/Continent.swift
@@ -7,15 +7,17 @@
 
 import Foundation
 
-public enum Continent: CaseIterable {
-    
-    case africa
-    case americas
-    case antartica
-    case asia
-    case europe
-    case oceania
-    
+public enum Continent: String, CaseIterable, CustomStringConvertible {
+
+    case africa = "Africa"
+    case americas = "Americas"
+    case antartica = "Antarctica"
+    case asia = "Asia"
+    case europe = "Europe"
+    case oceania = "Oceania"
+
+    public var description: String { rawValue }
+
     /// M-49 code for the continent
     /// More info: https://en.wikipedia.org/wiki/UN_M49
     var code: Int {
@@ -34,5 +36,6 @@ public enum Continent: CaseIterable {
             return 9
         }
     }
-    
+
+
 }

--- a/Sources/CountryKit/Models/Continent.swift
+++ b/Sources/CountryKit/Models/Continent.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum Continent {
+public enum Continent: CaseIterable {
     
     case africa
     case americas

--- a/Sources/CountryKit/Models/Country.swift
+++ b/Sources/CountryKit/Models/Country.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 public struct Country {
-    
     /// The continent for this country.
     public let continent: Continent
     
@@ -36,7 +35,27 @@ public struct Country {
     
     /// The phone extension for the country.
     public let phoneExtension: String
-    
+
+    public init(
+        continent: Continent,
+        region: Region,
+        subregion: Subregion? = nil,
+        name: String,
+        code: Int,
+        alpha2Code: String,
+        alpha3Code: String,
+        phoneExtension: String
+    ) {
+        self.continent = continent
+        self.region = region
+        self.subregion = subregion
+        self.name = name
+        self.code = code
+        self.alpha2Code = alpha2Code
+        self.alpha3Code = alpha3Code
+        self.phoneExtension = phoneExtension
+    }
+
     /// Get a localized translation for the country name.
     /// - Parameter locale: The locale to use
     /// - Returns: The localized country name (optional)

--- a/Sources/CountryKit/Models/Country.swift
+++ b/Sources/CountryKit/Models/Country.swift
@@ -36,6 +36,8 @@ public struct Country {
     /// The phone extension for the country.
     public let phoneExtension: String
 
+    public var flagEmoji: Character?
+
     public init(
         continent: Continent,
         region: Region,
@@ -54,6 +56,25 @@ public struct Country {
         self.alpha2Code = alpha2Code
         self.alpha3Code = alpha3Code
         self.phoneExtension = phoneExtension
+
+        self.flagEmoji = Self.emoji(alpha2Code: self.alpha2Code)
+    }
+
+    public static func emoji(alpha2Code: String) -> Character {
+        // https://stackoverflow.com/questions/30402435/swift-turn-a-country-code-into-a-emoji-flag-via-unicode
+        let base = UnicodeScalar("🇦").value - UnicodeScalar("A").value
+
+        var string = ""
+        alpha2Code.uppercased().unicodeScalars.forEach {
+            if let scalar = UnicodeScalar(base + $0.value) {
+                string.append(String(describing: scalar))
+            }
+        }
+
+        if string.count == 1 {
+            return Character(string)
+        }
+        return Character("❓")
     }
 
     /// Get a localized translation for the country name.
@@ -62,6 +83,5 @@ public struct Country {
     public func translation(for locale: Locale) -> String? {
         return locale.localizedString(forRegionCode: alpha2Code)
     }
-    
 }
 

--- a/Sources/CountryKit/Providers/AfricanCountriesProvider.swift
+++ b/Sources/CountryKit/Providers/AfricanCountriesProvider.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 public struct AfricanCountriesProvider: CountryProvidable {
-    
+    public init() {}
+
     public var countries = [
         Country(continent: .africa, region: .northernAfrica, subregion: nil, name: "Algeria", code: 12, alpha2Code: "DZ", alpha3Code: "DZA", phoneExtension: "213"),
         Country(continent: .africa, region: .northernAfrica, subregion: nil, name: "Egypt", code: 818, alpha2Code: "EG", alpha3Code: "EGY", phoneExtension: "20"),

--- a/Sources/CountryKit/Providers/AmericasCountriesProvider.swift
+++ b/Sources/CountryKit/Providers/AmericasCountriesProvider.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 public struct AmericasCountriesProvider: CountryProvidable {
-    
+    public init() {}
+
     public let countries = [
         Country(continent: .americas, region: .northAmerica, subregion: .northernAmerica, name: "Bermuda", code: 60, alpha2Code: "BM", alpha3Code: "BMU", phoneExtension: "1 (441)"),
         Country(continent: .americas, region: .northAmerica, subregion: .northernAmerica, name: "Canada", code: 124, alpha2Code: "CA", alpha3Code: "CAN", phoneExtension: "1"),

--- a/Sources/CountryKit/Providers/AsianCountriesProvider.swift
+++ b/Sources/CountryKit/Providers/AsianCountriesProvider.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 public struct AsianCountriesProvider: CountryProvidable {
-    
+    public init() {}
+
     public let countries = [
         Country(continent: .asia, region: .easternAsia, subregion: nil, name: "China", code: 156, alpha2Code: "CN", alpha3Code: "CHN", phoneExtension: "86"),
         Country(continent: .asia, region: .easternAsia, subregion: nil, name: "Hong Kong", code: 344, alpha2Code: "HK", alpha3Code: "HKG", phoneExtension: "852"),

--- a/Sources/CountryKit/Providers/EuropeanCountriesProvider.swift
+++ b/Sources/CountryKit/Providers/EuropeanCountriesProvider.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 public struct EuropeanCountriesProvider: CountryProvidable {
-    
+    public init() {}
+
     public let countries = [
         Country(continent: .europe, region: .southernEurope, subregion: nil, name: "Albania", code: 8, alpha2Code: "AL", alpha3Code: "ALB", phoneExtension: "355"),
         Country(continent: .europe, region: .southernEurope, subregion: nil, name: "Andorra", code: 20, alpha2Code: "AD", alpha3Code: "AND", phoneExtension: "376"),

--- a/Sources/CountryKit/Providers/OceanianCountriesProvider.swift
+++ b/Sources/CountryKit/Providers/OceanianCountriesProvider.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 public struct OceanianCountriesProvider: CountryProvidable {
-    
+    public init() {}
+
     public let countries = [
         Country(continent: .oceania, region: .australiaAndNewZealand, subregion: nil, name: "Australia", code: 36, alpha2Code: "AU", alpha3Code: "AUS", phoneExtension: "61"),
         Country(continent: .oceania, region: .australiaAndNewZealand, subregion: nil, name: "New Zealand", code: 554, alpha2Code: "NZ", alpha3Code: "NZL", phoneExtension: "64"),

--- a/Sources/CountryKit/Providers/WorldProvider.swift
+++ b/Sources/CountryKit/Providers/WorldProvider.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 public final class WorldProvider: CountryProvidable {
-    
+    public init() {}
+
     // MARK: - Properties
     public lazy var countries: [Country] = {
         return africanCountriesProvider.countries +

--- a/Tests/CountryKitTests/AfricanContinentProviderTests.swift
+++ b/Tests/CountryKitTests/AfricanContinentProviderTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import CountryKit
+import CountryKit
 
 final class AfricanContinentProviderTests: XCTestCase {
 

--- a/Tests/CountryKitTests/AmericasContinentProviderTests.swift
+++ b/Tests/CountryKitTests/AmericasContinentProviderTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import CountryKit
+import CountryKit
 
 final class AmericasContinentProviderTests: XCTestCase {
 

--- a/Tests/CountryKitTests/AsianContinentProviderTests.swift
+++ b/Tests/CountryKitTests/AsianContinentProviderTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import CountryKit
+import CountryKit
 
 final class AsianContinentProviderTests: XCTestCase {
 

--- a/Tests/CountryKitTests/ContinentTests.swift
+++ b/Tests/CountryKitTests/ContinentTests.swift
@@ -32,4 +32,9 @@ final class ContinentTests: XCTestCase {
 
         XCTAssertEqual(expected, Continent.allCases)
     }
+
+    func test_stringness() throws {
+        XCTAssertEqual("Oceania", Continent.oceania.rawValue)
+        XCTAssertEqual("Oceania", "\(Continent.oceania)")
+    }
 }

--- a/Tests/CountryKitTests/ContinentTests.swift
+++ b/Tests/CountryKitTests/ContinentTests.swift
@@ -1,0 +1,35 @@
+//
+//  ContinentTests.swift
+//
+//
+//  Created by Zach Holt on 8/4/23.
+//
+
+import Foundation
+
+import XCTest
+import CountryKit
+
+final class ContinentTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func test_enumerability() throws {
+        let expected = [
+            Continent.africa,
+            Continent.americas,
+            Continent.antartica,
+            Continent.asia,
+            Continent.europe,
+            Continent.oceania
+        ]
+
+        XCTAssertEqual(expected, Continent.allCases)
+    }
+}

--- a/Tests/CountryKitTests/CountryTests.swift
+++ b/Tests/CountryKitTests/CountryTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import CountryKit
+import CountryKit
 
 final class CountryTests: XCTestCase {
 

--- a/Tests/CountryKitTests/CountryTests.swift
+++ b/Tests/CountryKitTests/CountryTests.swift
@@ -57,4 +57,13 @@ final class CountryTests: XCTestCase {
         XCTAssertEqual(sut.translation(for: locale), "Belgien")
     }
     
+    func test_emoji_good() throws {
+        let sut = Country(continent: .europe, region: .westernEurope, subregion: nil, name: "Belgium", code: 56, alpha2Code: "BE", alpha3Code: "BEL", phoneExtension: "32")
+        XCTAssertEqual("🇧🇪", sut.flagEmoji)
+    }
+
+    func test_emoji_bad() throws {
+        let sut = Country(continent: .europe, region: .westernEurope, subregion: nil, name: "Belgium", code: 56, alpha2Code: "NO SUCH EMOJI FLAG", alpha3Code: "BEL", phoneExtension: "32")
+        XCTAssertEqual("❓", sut.flagEmoji)
+    }
 }

--- a/Tests/CountryKitTests/EuropeanContinentProviderTests.swift
+++ b/Tests/CountryKitTests/EuropeanContinentProviderTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import CountryKit
+import CountryKit
 
 final class EuropeanContinentProviderTests: XCTestCase {
 

--- a/Tests/CountryKitTests/OceanianContinentProviderTests.swift
+++ b/Tests/CountryKitTests/OceanianContinentProviderTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import CountryKit
+import CountryKit
 
 final class OceanianContinentProviderTests: XCTestCase {
 

--- a/Tests/CountryKitTests/WorldProviderTests.swift
+++ b/Tests/CountryKitTests/WorldProviderTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import CountryKit
+import CountryKit
 
 final class WorldProviderTests: XCTestCase {
 


### PR DESCRIPTION
As it stands in [countrykit#bb14a53c](https://github.com/frederik-jacques/countrykit/commit/bb14a53cffa7a25cb8f73ff5275bbb68f437141c), I am unable to instantiate any providers when I import the package into my project.  This is due to [the way default initializers are created](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/accesscontrol/#Default-Initializers).

In an effort to more closely mimic the context of a consumer of this package, this PR removes the @testable attribute from the import statements in tests.  Public `init()`s are then required on providers and Country.